### PR TITLE
Add module prefix for Operations. 

### DIFF
--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/rfc8040/PathHandler.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/rfc8040/PathHandler.java
@@ -141,7 +141,7 @@ class PathHandler implements com.mrv.yangtools.codegen.PathHandler {
                     .description(description));
         }
         post.response(201, new Response().description("No response")); //no output body
-        swagger.path(operations + printer.path(), new Path().post(post));
+        swagger.path(operations + module.getName() + ':' + printer.path(), new Path().post(post));
     }
 
     private List<String> tags(PathSegment pathCtx) {


### PR DESCRIPTION
I noticed that the paths for .../operations/ in the RFC spec require the module name before the operation name. 
For example instead of `/restconf/operations/reset` if 'reset' was inside a 'system' module it should look like this `/restconf/operations/system:reset`

```
For example, if "module-A" defined a "reset" RPC operation, then
   invoking the operation would be requested as follows:

      POST /restconf/operations/module-A:reset HTTP/1.1
```
more details can be found here.
https://tools.ietf.org/html/rfc8040#section-3.6