### PR TITLE
Add module descriptions if available

### DIFF
--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/IoCSwaggerGenerator.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/IoCSwaggerGenerator.java
@@ -290,6 +290,7 @@ public class IoCSwaggerGenerator {
     public Swagger generate() {
 
         ArrayList<String> mNames = new ArrayList<>();
+        ArrayList<String> mDescs = new ArrayList<>();
 
         if(ctx.getModules().isEmpty() || modules.isEmpty()) {
             log.info("No modules found to be transformed into swagger definition");
@@ -301,6 +302,9 @@ public class IoCSwaggerGenerator {
 
         modules.forEach(m -> {
             mNames.add(m.getName());
+            if(m.getDescription() != null && !m.getDescription().isEmpty()) {
+                mDescs.add(m.getDescription());
+            }
             dataObjectsBuilder.processModule(m);
 
         });
@@ -309,10 +313,11 @@ public class IoCSwaggerGenerator {
 
         modules.forEach(m -> new ModuleGenerator(m).generate());
 
-        // update info with module names
+        // update info with module names and descriptions
         String modules = mNames.stream().collect(Collectors.joining(","));
+        String descriptions = mDescs.stream().collect(Collectors.joining(","));
         target.getInfo()
-                .description(modules + " API generated from yang definitions")
+                .description(descriptions)
                 .title(modules + " API");
 
         postProcessSwagger(target);

--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/SwaggerGenerator.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/SwaggerGenerator.java
@@ -280,6 +280,7 @@ public class SwaggerGenerator {
     public Swagger generate() {
 
         ArrayList<String> mNames = new ArrayList<>();
+        ArrayList<String> mDescs = new ArrayList<>();
 
         if(ctx.getModules().isEmpty() || modules.isEmpty()) {
             log.info("No modules found to be transformed into swagger definition");
@@ -291,6 +292,9 @@ public class SwaggerGenerator {
 
         modules.forEach(m -> {
             mNames.add(m.getName());
+            if(m.getDescription() != null && !m.getDescription().isEmpty()) {
+                mDescs.add(m.getDescription());
+            }
             dataObjectsBuilder.processModule(m);
 
         });
@@ -299,10 +303,15 @@ public class SwaggerGenerator {
 
         modules.forEach(m -> new ModuleGenerator(m).generate());
 
-        // update info with module names
+        // update info with module names and descriptions
         String modules = mNames.stream().collect(Collectors.joining(","));
+        String descriptions = mDescs.stream().collect(Collectors.joining(","));
+        if(descriptions.isEmpty()) {
+            descriptions = modules + " API generated from yang definitions";
+        }
+
         target.getInfo()
-                .description(modules + " API generated from yang definitions")
+                .description(descriptions)
                 .title(modules + " API");
 
         postProcessSwagger(target);


### PR DESCRIPTION
This adds module descriptions if they are available. If there are multiple modules, they are comma separated just like the names.

Issue: https://github.com/bartoszm/yang2swagger/issues/4