### PR TITLE
Add exit status code for errors

### DIFF
--- a/cli/src/main/java/com/mrv/yangtools/codegen/main/Main.java
+++ b/cli/src/main/java/com/mrv/yangtools/codegen/main/Main.java
@@ -95,6 +95,7 @@ public class Main {
             parser.printUsage(System.err);
         } catch (Throwable t) {
             log.error("Error while generating Swagger", t);
+            System.exit(-1);
         }
     }
 


### PR DESCRIPTION
This adds an exit status code to make it easier to test for errors in test suites or continuous integration.

It could be improved to use a variable and a flag that allows warnings to be treated as errors, but this should work for now as an improvement. 