### PR TITLE
Add call level descriptions

### DIFF
--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/DeleteOperationGenerator.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/DeleteOperationGenerator.java
@@ -29,7 +29,10 @@ public class DeleteOperationGenerator extends OperationGenerator {
     @Override
     public Operation execute(DataSchemaNode node) {
         final Operation delete = defaultOperation();
-        delete.description("removes " + getName(node));
+        delete.summary("removes " + getName(node));
+        String description = node.getDescription() == null ? "removes " + getName(node) :
+                node.getDescription();
+        delete.description(description);
         delete.response(204, new Response().description("Object deleted"));
         return delete;
     }

--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/GetOperationGenerator.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/GetOperationGenerator.java
@@ -30,7 +30,10 @@ public class GetOperationGenerator extends OperationGenerator {
     @Override
     public Operation execute(DataSchemaNode node) {
         final Operation get = defaultOperation();
-        get.description("returns " + getName(node));
+        get.summary("returns " + getName(node));
+        String description = node.getDescription() == null ? "returns " + getName(node) :
+                node.getDescription();
+        get.description(description);
         get.response(200, new Response()
                 .schema(new RefProperty(getDefinitionId(node)))
                 .description(getName(node)));

--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/PostOperationGenerator.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/PostOperationGenerator.java
@@ -35,7 +35,10 @@ public class PostOperationGenerator extends OperationGenerator {
     public Operation execute(DataSchemaNode node) {
         final Operation post = dropLastSegmentParameters ? listOperation() : defaultOperation();
         final RefModel definition = new RefModel(getDefinitionId(node));
-        post.description("creates " + getName(node));
+        post.summary("creates " + getName(node));
+        String description = node.getDescription() == null ? "creates " + getName(node) :
+                node.getDescription();
+        post.description(description);
         post.parameter(new BodyParameter()
                 .name(getName(node) + ".body-param")
                 .schema(definition)

--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/PutOperationGenerator.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/path/PutOperationGenerator.java
@@ -32,7 +32,10 @@ public class PutOperationGenerator extends OperationGenerator {
     public Operation execute(DataSchemaNode node) {
         final Operation put = defaultOperation();
         final RefModel definition = new RefModel(getDefinitionId(node));
-        put.description("creates or updates " + getName(node));
+        put.summary("creates or updates " + getName(node));
+        String description = node.getDescription() == null ? "creates or updates " + getName(node) :
+                node.getDescription();
+        put.description(description);
         put.parameter(new BodyParameter()
                 .name(getName(node) + ".body-param")
                 .schema(definition)


### PR DESCRIPTION
This adds call level descriptions for #4. It is possibly a breaking change, depending on how the swagger `description` field was used before.

I moved the contents of the current `description` field to the `summary` field and replaced the existing `description` contents with the node description (if it exists), as that is how **swagger-ui** and **reDoc** digest those fields so it seemed to be the proper usage.