### PR TITLE
Create bug reproducer

### DIFF
--- a/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorAugmentationsTestIt.java
+++ b/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorAugmentationsTestIt.java
@@ -28,7 +28,7 @@ public class SwaggerGeneratorAugmentationsTestIt extends AbstractItTest {
         assertEquals(3, swagger.getPaths().entrySet().stream().filter(e -> e.getKey().contains("g2-c-c1")).count());
         assertEquals(3, swagger.getDefinitions().keySet().stream().filter(e -> e.contains("augmenting")).count());
         assertEquals(11, swagger.getDefinitions().keySet().size());
-        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.groupingroot.G1", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
+        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.groupingroot.G4", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
         Model model = swagger.getDefinitions().get("with.groupings.GroupingRoot");
         RefProperty groupingChild2 = (RefProperty) model.getProperties().get("grouping-child2");
         assertEquals("with.groupings.groupingroot.GroupingChild2", groupingChild2.getSimpleRef());

--- a/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorAugmentationsTestIt.java
+++ b/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorAugmentationsTestIt.java
@@ -28,7 +28,7 @@ public class SwaggerGeneratorAugmentationsTestIt extends AbstractItTest {
         assertEquals(3, swagger.getPaths().entrySet().stream().filter(e -> e.getKey().contains("g2-c-c1")).count());
         assertEquals(3, swagger.getDefinitions().keySet().stream().filter(e -> e.contains("augmenting")).count());
         assertEquals(11, swagger.getDefinitions().keySet().size());
-        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.groupingroot.G4", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
+        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.G1", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
         Model model = swagger.getDefinitions().get("with.groupings.GroupingRoot");
         RefProperty groupingChild2 = (RefProperty) model.getProperties().get("grouping-child2");
         assertEquals("with.groupings.groupingroot.GroupingChild2", groupingChild2.getSimpleRef());

--- a/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorTestIt.java
+++ b/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorTestIt.java
@@ -90,7 +90,7 @@ public class SwaggerGeneratorTestIt extends AbstractItTest {
         //then
         assertEquals(3, swagger.getPaths().entrySet().stream().filter(e -> e.getKey().contains("g2-c-c1")).count());
         assertEquals(7, swagger.getDefinitions().keySet().size());
-        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.groupingroot.G1", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
+        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.groupingroot.G4", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
         Model model = swagger.getDefinitions().get("with.groupings.GroupingRoot");
         RefProperty groupingChild2 = (RefProperty) model.getProperties().get("grouping-child2");
         assertEquals("with.groupings.G2", groupingChild2.getSimpleRef());

--- a/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorTestIt.java
+++ b/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorTestIt.java
@@ -16,6 +16,7 @@ import io.swagger.models.Model;
 import io.swagger.models.Path;
 import io.swagger.models.properties.RefProperty;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 
 import java.util.Arrays;
@@ -90,7 +91,8 @@ public class SwaggerGeneratorTestIt extends AbstractItTest {
         //then
         assertEquals(3, swagger.getPaths().entrySet().stream().filter(e -> e.getKey().contains("g2-c-c1")).count());
         assertEquals(7, swagger.getDefinitions().keySet().size());
-        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.groupingroot.G4", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
+        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.G2", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
+        assertThat(swagger.getDefinitions().keySet(), not(hasItem(ArgumentMatchers.endsWith("G4"))));
         Model model = swagger.getDefinitions().get("with.groupings.GroupingRoot");
         RefProperty groupingChild2 = (RefProperty) model.getProperties().get("grouping-child2");
         assertEquals("with.groupings.G2", groupingChild2.getSimpleRef());

--- a/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorTestIt.java
+++ b/swagger-generator/src/test/java/com/mrv/yangtools/codegen/SwaggerGeneratorTestIt.java
@@ -16,7 +16,6 @@ import io.swagger.models.Model;
 import io.swagger.models.Path;
 import io.swagger.models.properties.RefProperty;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 
 import java.util.Arrays;
@@ -91,8 +90,8 @@ public class SwaggerGeneratorTestIt extends AbstractItTest {
         //then
         assertEquals(3, swagger.getPaths().entrySet().stream().filter(e -> e.getKey().contains("g2-c-c1")).count());
         assertEquals(7, swagger.getDefinitions().keySet().size());
-        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.G2", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
-        assertThat(swagger.getDefinitions().keySet(), not(hasItem(ArgumentMatchers.endsWith("G4"))));
+        assertThat(swagger.getDefinitions().keySet(), hasItems("with.groupings.G1", "with.groupings.G2", "with.groupings.g2.g2c.G3"));
+        assertThat(swagger.getDefinitions().keySet(), not(hasItem(endsWith("G4"))));
         Model model = swagger.getDefinitions().get("with.groupings.GroupingRoot");
         RefProperty groupingChild2 = (RefProperty) model.getProperties().get("grouping-child2");
         assertEquals("with.groupings.G2", groupingChild2.getSimpleRef());

--- a/swagger-generator/src/test/resources/with-groupings.yang
+++ b/swagger-generator/src/test/resources/with-groupings.yang
@@ -48,7 +48,7 @@ module with-groupings {
   }
 
   container grouping-root {
-    grouping g1 {
+    grouping g4 {
       leaf g1-l2 {
           type string;
       }


### PR DESCRIPTION
Adapt tests to prove that grouping definitions dont follow
hierarchy of the module but instead they depends on grouping naming.

When we change groupingroot.G1 to groupingroot.G4 we are no more able
to get its definition because its is replaced by previously "rewritten"
G1 grouping which was not defined without this change:

Try to run test without this patch - you can see that we have
definition for G2 but not for G1, instead we have groupingroot.G1!

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>