### PR TITLE
Replace getSchema() with getResponseSchema() in SwaggerRefHelper

### DIFF
--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/SwaggerRefHelper.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/SwaggerRefHelper.java
@@ -88,19 +88,18 @@ public class SwaggerRefHelper {
         Response response = oper.getResponses().get(responseCode);
         if(response == null) return null;
 
-        Property prop = response.getSchema();
+        Model prop = response.getResponseSchema();
+        Property outputProperty = null;
 
-        if(prop instanceof ObjectProperty) {
-            prop = ((ObjectProperty) prop).getProperties().get("output");
+        if(prop instanceof RefModel) {
+            return ((RefModel)prop).getSimpleRef();
+        } else if(prop != null) {
+          outputProperty = prop.getProperties().get("output");
         }
 
-        if(prop instanceof RefProperty) {
-            return ((RefProperty)prop).getSimpleRef();
-        }
+        if(prop == null || outputProperty == null) return null;
 
-        if(prop == null) return null;
-
-        RefProperty schema = (RefProperty) prop;
+        RefProperty schema = (RefProperty) outputProperty;
         return schema.getSimpleRef();
     }
 

--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/TypesUsageTreeBuilder.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/TypesUsageTreeBuilder.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
  * Type usage builder. There are two types of relations supported
  * <ul>
  *     <li>uses</li> - poitned by properties of a given definition
- *     <li>references</li> - part of composition of a hgiven definition
+ *     <li>references</li> - part of composition of a given definition
  * </ul>
  * @author bartosz.michalik@amartus.com
  */

--- a/swagger-generator/src/test/java/com/mrv/yangtools/codegen/impl/postprocessor/SwaggerRefHelperTest.java
+++ b/swagger-generator/src/test/java/com/mrv/yangtools/codegen/impl/postprocessor/SwaggerRefHelperTest.java
@@ -1,0 +1,27 @@
+package com.mrv.yangtools.codegen.impl.postprocessor;
+
+import io.swagger.models.Path;
+import io.swagger.models.Operation;
+import io.swagger.models.Response;
+import io.swagger.models.RefModel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static com.mrv.yangtools.codegen.impl.postprocessor.SwaggerRefHelper.*;
+
+/**
+ * @author scott@aliroquantum.com
+ */
+public class SwaggerRefHelperTest extends AbstractWithSwagger {
+  @Test
+  public void getFromResponseTest() {
+    String success = "200";
+    String newModel = "NewModel";
+    Path path = swagger.getPath("/b/propE");
+    Operation operation = path.getGet();
+    Response response = operation.getResponses().get(success);
+    response.setResponseSchema(new RefModel(newModel));
+    String schema = getFromResponse(operation,success);
+    assertEquals(schema,newModel);
+  }
+}


### PR DESCRIPTION
This PR fixes a bug in `SwaggerRefHelper`. 

When `PayloadWrapperProcessor` creates a "wrapped" definition, it sets it in the response property using `setResponseSchema`. 

https://github.com/bartoszm/yang2swagger/blob/4f513295e28612df4672b3ddb9ef8bc2456654b4/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/PayloadWrapperProcessor.java#L63-L66

`SwaggerRefHelper` then attempts to retrieve the reference using the [deprecated](https://www.javadoc.io/static/io.swagger/swagger-models/1.6.6/io/swagger/models/Response.html#getSchema--) `getSchema()`.

https://github.com/bartoszm/yang2swagger/blob/4f513295e28612df4672b3ddb9ef8bc2456654b4/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/SwaggerRefHelper.java#L91

This causes yang2swagger to miss some references, and remove models that are in fact referenced in the generated swagger.

I am proposing a change to replace `getSchema()` with the updated `getResponseSchema()` to solve this problem.