### PR TITLE
Add mount-point support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Our tool supports:
  * groupings - which, depending on strategy, are either unpacked into models that use these groupings or optimized model inheritance structures
  * augmentations - which, depending on strategy, are either unpacked into models that use these groupings or optimized model inheritance structures
  * YANG modules documentation - which is added to generated swagger API specification
+ * mount-point - for which types can be provided during swagger generation
 
 
 In this project we use YANG parser from [OpenDaylight](https://www.opendaylight.org/) (ODL) yang-tools project. The generated Swagger specification is available as Java object or serialized either to YAML or JSON file.
@@ -76,6 +77,17 @@ module ...                             : List of YANG module names to generate
                                          defaults to current directory.
                                          Multiple dirs might be separated by
                                          system path separator (default: )
+ -mount-point-mappings                 : Mount-point mappings as a JSON string.  
+                                         Assigns mount-point labels (from YANG
+                                         files) to lists of content types
+                                         that should be used when generating 
+                                         Swagger definitions. Expected format:
+                                         '{"mount-label": ["module:grouping", ...]}'
+                                         Example:
+                                         '{"list-entry-data": [
+                                         "entry-type-1:content",
+                                         "entry-type-2:content"
+                                         ]}'
 ```
 
 For example:

--- a/cli/src/main/java/com/mrv/yangtools/codegen/main/Main.java
+++ b/cli/src/main/java/com/mrv/yangtools/codegen/main/Main.java
@@ -9,6 +9,8 @@
 
 package com.mrv.yangtools.codegen.main;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mrv.yangtools.codegen.SwaggerGenerator;
 import com.mrv.yangtools.codegen.impl.path.AbstractPathHandlerBuilder;
 import com.mrv.yangtools.codegen.impl.path.odl.ODLPathHandlerBuilder;
@@ -34,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -86,6 +89,10 @@ public class Main {
 
     @Option(name = "-basepath", usage="")
     public String basePath = "localhost:1234";
+
+    // New option to accept mount-point mappings as JSON string
+    @Option(name = "-mount-point-mappings", usage = "Mount point mappings as JSON string, e.g. '{\"list-entry-data\": [\"entry-type-1:content\", \"entry-type-2:content\"]}'", metaVar = "json")
+    public String mountPointMappings = "";
 
     public enum ElementType {
         DATA, RPC, DATA_AND_RPC
@@ -160,7 +167,15 @@ public class Main {
                 .pathHandler(pathHandler)
                 .elements(map(elementType));
 
-
+        // parse and set mount-point mappings if provided
+        if (mountPointMappings != null && !mountPointMappings.trim().isEmpty()) {
+            log.debug("Raw mount-point-mappings arg: {}", mountPointMappings);
+            Map<String, List<String>> mapping = parseMountPointMappings(mountPointMappings);
+            log.debug("Parsed mount-point-mappings: {}", mapping);
+            if (mapping != null && !mapping.isEmpty()) {
+                generator.yangmntMappings(mapping);
+            }
+        }
 
         if(AuthenticationMechanism.BASIC.equals(authenticationMechanism)) {
             generator.appendPostProcessor(new AddSecurityDefinitions().withSecurityDefinition("api_sec", new BasicAuthDefinition()));
@@ -182,6 +197,41 @@ public class Main {
         generator.appendPostProcessor(new RemoveUnusedDefinitions());
 
         generator.generate(new OutputStreamWriter(out));
+    }
+
+    private Map<String, List<String>> parseMountPointMappings(String raw) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            Map<String, List<String>> rm = mapper.readValue(raw, new TypeReference<Map<String, List<String>>>(){});
+            log.debug("parseMountPointMappings parsed map size={}", rm == null ? 0 : rm.size());
+            // basic validation: non-null keys and non-empty list values with non-empty items
+            if (rm == null) {
+                log.error("Parsed mount-point mappings is null for input: {}", raw);
+                throw new IllegalArgumentException("mount-point-mappings must be a JSON object mapping strings to list of strings");
+            }
+            for (Map.Entry<String, List<String>> e : rm.entrySet()) {
+                if (e.getKey() == null || e.getKey().trim().isEmpty()) {
+                    log.error("Invalid mount-point-mappings: contains empty key. Input: {}", raw);
+                    throw new IllegalArgumentException("mount-point-mappings contains empty key");
+                }
+                if (e.getValue() == null || e.getValue().isEmpty()) {
+                    log.error("Invalid mount-point-mappings: value list empty for key {}. Input: {}", e.getKey(), raw);
+                    throw new IllegalArgumentException("mount-point-mappings contains empty list for key: " + e.getKey());
+                }
+                for (String v : e.getValue()) {
+                    if (v == null || v.trim().isEmpty()) {
+                        log.error("Invalid mount-point-mappings: contains empty mapping item for key {}. Input: {}", e.getKey(), raw);
+                        throw new IllegalArgumentException("mount-point-mappings contains empty mapping for key: " + e.getKey());
+                    }
+                }
+            }
+            return rm;
+        } catch (IllegalArgumentException iae) {
+            throw iae;
+        } catch (Exception e) {
+            log.error("Invalid mount-point-mappings format: {}", raw, e);
+            throw new IllegalArgumentException("Invalid mount-point-mappings format", e);
+        }
     }
 
     private void validate(String basePath) {

--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/SwaggerGenerator.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/SwaggerGenerator.java
@@ -17,6 +17,7 @@ import com.mrv.yangtools.codegen.impl.AnnotatingTypeConverter;
 import com.mrv.yangtools.codegen.impl.ModuleUtils;
 import com.mrv.yangtools.codegen.impl.OptimizingDataObjectBuilder;
 import com.mrv.yangtools.codegen.impl.UnpackingDataObjectsBuilder;
+import com.mrv.yangtools.codegen.impl.postprocessor.MountPointPostProcessor;
 import com.mrv.yangtools.codegen.impl.postprocessor.ReplaceEmptyWithParent;
 import com.mrv.yangtools.codegen.impl.postprocessor.SortComplexModels;
 import com.mrv.yangtools.common.SwaggerUtils;
@@ -66,6 +67,7 @@ public class SwaggerGenerator {
     private Set<Elements> toGenerate;
     private final AnnotatingTypeConverter converter;
     private PathHandlerBuilder pathHandlerBuilder;
+    private Map<String, List<String>> yangmntMappings = Collections.emptyMap();
 
     public SwaggerGenerator defaultConfig() {
         //setting defaults
@@ -262,7 +264,19 @@ public class SwaggerGenerator {
     public SwaggerGenerator maxDepth(int maxDepth) {
     	this.maxDepth = maxDepth;
         return this;
-    }    
+    }
+
+    /**
+     * Provide mappings for mount-point extension: label -> list of module:grouping strings
+     */
+    public SwaggerGenerator yangmntMappings(Map<String, List<String>> mappings) {
+        this.yangmntMappings = mappings == null ? Collections.emptyMap() : mappings;
+        if(yangmntMappings != null && !yangmntMappings.isEmpty()) {
+            // run a lightweight post processor to update composed models for mount-points
+            this.appendPostProcessor(new MountPointPostProcessor(yangmntMappings, ctx, moduleUtils, (com.mrv.yangtools.codegen.DataObjectRepo) dataObjectsBuilder));
+        }
+        return this;
+    }
 
     /**
      * Run Swagger generation for configured modules. Write result to target. The file format

--- a/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/MountPointPostProcessor.java
+++ b/swagger-generator/src/main/java/com/mrv/yangtools/codegen/impl/postprocessor/MountPointPostProcessor.java
@@ -1,0 +1,586 @@
+package com.mrv.yangtools.codegen.impl.postprocessor;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.RefModel;
+import io.swagger.models.Swagger;
+import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
+import com.mrv.yangtools.codegen.impl.ModuleUtils;
+import com.mrv.yangtools.codegen.impl.DataNodeHelper;
+import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.DataNodeContainer;
+
+import java.util.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.mrv.yangtools.codegen.DataObjectRepo;
+import com.mrv.yangtools.codegen.DataObjectBuilder;
+import org.opendaylight.yangtools.yang.model.api.GroupingDefinition;
+import org.opendaylight.yangtools.yang.model.api.ContainerSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
+
+/**
+ * Lightweight postprocessor that attaches mount definitions to target models.
+ */
+public class MountPointPostProcessor implements java.util.function.Consumer<Swagger> {
+    private static final Logger log = LoggerFactory.getLogger(MountPointPostProcessor.class);
+
+    private static volatile boolean declaredAccessRestricted = false;
+
+    private final Map<String, List<String>> mappings;
+    private final EffectiveModelContext ctx;
+    private final ModuleUtils moduleUtils;
+    private final DataObjectRepo dataRepo;
+
+    public MountPointPostProcessor(Map<String, List<String>> mappings, EffectiveModelContext ctx, ModuleUtils moduleUtils, DataObjectRepo dataRepo) {
+        this.mappings = mappings == null ? Collections.emptyMap() : mappings;
+        this.ctx = ctx;
+        this.moduleUtils = moduleUtils;
+        this.dataRepo = dataRepo;
+    }
+
+    // Collect mount-point labels across all modules and return mapping label -> list of DataNodeContainer nodes
+    private Map<String, List<DataNodeContainer>> getMointPointFromModules() {
+        Map<String, List<DataNodeContainer>> nodesByLabel = new HashMap<>();
+        ctx.getModules()
+                .forEach(module -> collectMountPointsFromContainer(module, nodesByLabel));
+        return nodesByLabel;
+    }
+
+    // Scan provided container (module/container/list) for DataSchemaNode instances and try to find mount-point label on each
+    private void collectMountPointsFromContainer(DataNodeContainer container, Map<String, List<DataNodeContainer>> nodesByLabel) {
+        // For debugging keep basic info
+        log.debug("Scanning container for mount-points: {}", container);
+
+        // DataNodeHelper.stream(container) yields schema nodes; check each for mount-point extension
+        DataNodeHelper.stream(container)
+                .filter(n -> n instanceof DataSchemaNode)
+                .map(n -> (DataSchemaNode) n)
+                .forEach(node -> {
+                    String label = findMountPointLabel(node);
+                    if (label != null && !label.isEmpty()) {
+                        log.info("Found mount-point label '{}' in node {}", label, node);
+                        // ensure we store the container node (only Container/List are DataNodeContainer)
+                        if (node instanceof DataNodeContainer) {
+                            nodesByLabel.computeIfAbsent(label, k -> new ArrayList<>()).add((DataNodeContainer) node);
+                        } else {
+                            // in some models the mount-point may appear on grouping or other statement; try to attach parent container
+                            // find parent container by walking up via module scan (best-effort)
+                            // fallback: add the module root as the container
+                            // note: Module also implements DataNodeContainer, so add module if no better parent
+                            nodesByLabel.computeIfAbsent(label, k -> new ArrayList<>()).add(container);
+                        }
+                    }
+                });
+
+        // Additionally, check groupings inside the container (groupings are not DataSchemaNode) using DataNodeHelper
+        DataNodeHelper.stream(container)
+                .filter(n -> n instanceof GroupingDefinition)
+                .map(n -> (GroupingDefinition) n)
+                .forEach(g -> {
+                    String label = findMountPointLabel(g);
+                    if (label != null && !label.isEmpty()) {
+                        log.info("Found mount-point label '{}' in grouping {}", label, g);
+                        // groupings are not DataNodeContainer, associate to the module-level container
+                        nodesByLabel.computeIfAbsent(label, k -> new ArrayList<>()).add(container);
+                    }
+                });
+    }
+
+    @Override
+    public void accept(Swagger swagger) {
+        if(swagger.getDefinitions() == null || swagger.getDefinitions().isEmpty()) return;
+
+        // build a set of candidate refs based on provided module:grouping strings
+        Map<String, String> candidateDefs = new HashMap<>();
+        if(swagger.getDefinitions() != null) {
+            for(String s : swagger.getDefinitions().keySet()) {
+                candidateDefs.put(s.toLowerCase(), s);
+            }
+        }
+
+        // collect nodes by mount-point label
+        Map<String, List<DataNodeContainer>> nodesByLabel = getMointPointFromModules();
+
+        if(nodesByLabel.isEmpty()) {
+            log.info("No mount-point extensions found in model");
+            return;
+        }
+
+        // for each found mount label, look up CLI mapping and attach definitions to corresponding swagger models
+        for(Map.Entry<String, List<DataNodeContainer>> entry : nodesByLabel.entrySet()) {
+            String label = entry.getKey();
+            List<String> mapped = mappings.get(label);
+            if(mapped == null || mapped.isEmpty()) continue;
+
+            // resolve mapped module:grouping entries to definition refs using context and dataRepo
+            List<RefModel> refModels = new ArrayList<>();
+            for(String map : mapped) {
+                String[] parts = map.split(":",2);
+                String modulePart = parts.length > 0 ? parts[0].trim() : "";
+                String namePart = parts.length > 1 ? parts[1].trim() : parts[0].trim();
+
+                String defRef = null;
+                Object resolvedNode = null;
+                // 1) try groupings
+                for(GroupingDefinition g : ctx.getGroupings()) {
+                    String gLocal = g.getQName().getLocalName();
+                    String gModule = moduleUtils.toModuleName(g);
+                    if(gLocal.equals(namePart) && (modulePart.isEmpty() || gModule.equals(modulePart))) {
+                        try { defRef = dataRepo.getDefinitionRef(g); resolvedNode = g; } catch (Exception e) { defRef = null; resolvedNode = null; }
+                        if(defRef != null) break;
+                    }
+                }
+                // 2) try containers/lists
+                if(defRef == null) {
+                    Iterator<org.opendaylight.yangtools.yang.model.api.SchemaNode> it = DataNodeHelper.stream(ctx)
+                            .filter(n -> n instanceof ContainerSchemaNode || n instanceof ListSchemaNode)
+                            .iterator();
+                    while(it.hasNext()) {
+                        org.opendaylight.yangtools.yang.model.api.SchemaNode candidate = it.next();
+                        if(!(candidate instanceof DataSchemaNode)) continue;
+                        DataSchemaNode ds = (DataSchemaNode) candidate;
+                        String local = ds.getQName().getLocalName();
+                        String candModule = moduleUtils.toModuleName(ds);
+                        if(local.equals(namePart) && (modulePart.isEmpty() || candModule.equals(modulePart))) {
+                            try { defRef = resolveDefinition((DataNodeContainer)ds); resolvedNode = ds; } catch (Exception e) { defRef = null; resolvedNode = null; }
+                            if(defRef != null) break;
+                        }
+                    }
+                }
+                // 3) fallback to previous candidateDefs heuristic
+                if(defRef == null && !candidateDefs.isEmpty()) {
+                    String lower = namePart.toLowerCase();
+                    Optional<String> match = candidateDefs.keySet().stream().filter(k -> k.contains(lower) && (modulePart.isEmpty() || k.contains(modulePart.toLowerCase()))).findFirst();
+                    if(match.isPresent()) defRef = "#/definitions/" + candidateDefs.get(match.get());
+                }
+
+                if(defRef != null) {
+                    // ensure simple ref (strip prefix)
+                    String simple = defRef.startsWith("#/definitions/") ? defRef.substring("#/definitions/".length()) : defRef;
+
+                    // If definition missing in swagger definitions, try to create it using data object builder
+                    if(!swagger.getDefinitions().containsKey(simple) && resolvedNode != null && dataRepo instanceof DataObjectBuilder) {
+                        try {
+                            DataObjectBuilder builder = (DataObjectBuilder) dataRepo;
+                            String name = null;
+                            try {
+                                name = getNameUnchecked(resolvedNode);
+                            } catch (Exception e) {
+                                // ignore
+                            }
+                            if(name != null) {
+                                try {
+                                    addModelUnchecked(builder, resolvedNode, name);
+                                } catch (ClassCastException cce) {
+                                    try {
+                                        addModelUnchecked(builder, resolvedNode);
+                                    } catch (Exception ex) {
+                                        log.warn("Cannot create definition for mapping {}: {}", map, ex.toString());
+                                    }
+                                } catch (Exception ex) {
+                                    log.warn("Cannot create definition for mapping {}: {}", map, ex.toString());
+                                }
+                            } else {
+                                try {
+                                    addModelUnchecked(builder, resolvedNode);
+                                } catch (Exception ex) {
+                                    log.warn("Cannot create definition for mapping {}: {}", map, ex.toString());
+                                }
+                            }
+                        } catch (Exception e) {
+                            log.warn("Creating definition for mapping {} failed: {}", map, e.toString());
+                        }
+                    }
+
+                    refModels.add(new RefModel("#/definitions/" + simple));
+                } else {
+                    log.warn("Cannot resolve mapping entry '{}' for mount label {}", map, label);
+                }
+            }
+
+            if(refModels.isEmpty()) continue;
+
+            // attach to each node's generated definition (resolve via DataObjectRepo)
+            for(DataNodeContainer node : entry.getValue()) {
+                String defRef;
+                try {
+                    defRef = resolveDefinition(node);
+                } catch (Exception e) {
+                    log.warn("Cannot resolve definition ref for node {}: {}", getNodeId(node), e.toString());
+                    continue;
+                }
+                if(defRef == null || defRef.isEmpty()) {
+                    log.warn("No swagger definition found for node {} to attach mount refs", getNodeId(node));
+                    continue;
+                }
+                // get original model if present
+                String simpleRef = defRef.startsWith("#/definitions/") ? defRef.substring("#/definitions/".length()) : defRef;
+                Model original = swagger.getDefinitions().get(simpleRef);
+
+                // remember whether the original already contained an empty inline 'object' entry
+                boolean hadEmptyObjectBefore = false;
+                if(original instanceof ComposedModel) {
+                    List<Model> origAllOf = ((ComposedModel) original).getAllOf();
+                    if(origAllOf != null) {
+                        for(Model o : origAllOf) {
+                            if(o instanceof ModelImpl) {
+                                ModelImpl mm = (ModelImpl) o;
+                                String t = mm.getType();
+                                java.util.Map<String, ?> props = mm.getProperties();
+                                if("object".equals(t) && (props == null || props.isEmpty())) {
+                                    hadEmptyObjectBefore = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                } else if(original instanceof ModelImpl) {
+                    ModelImpl mm = (ModelImpl) original;
+                    String t = mm.getType();
+                    java.util.Map<String, ?> props = mm.getProperties();
+                    if("object".equals(t) && (props == null || props.isEmpty())) {
+                        hadEmptyObjectBefore = true;
+                    }
+                }
+
+                ComposedModel cm = new ComposedModel();
+                cm.setInterfaces(refModels);
+
+                // set parent interface if available
+                if(!refModels.isEmpty()) cm.parent(refModels.get(0));
+
+                if(original instanceof ModelImpl) {
+                    ModelImpl mi = (ModelImpl) original;
+                    ModelImpl copy = new ModelImpl();
+                    copy.setType(mi.getType());
+                    copy.setProperties(mi.getProperties());
+                    copy.setDescription(mi.getDescription());
+                    cm.child(copy);
+                } else if (original instanceof ComposedModel) {
+                    // preserve original allOf entries where possible to avoid dropping existing components
+                    ComposedModel origCm = (ComposedModel) original;
+                    List<Model> origAll = origCm.getAllOf();
+                    if(origAll != null && !origAll.isEmpty()) {
+                        List<Model> targetAll = cm.getAllOf();
+                        if(targetAll == null) {
+                            targetAll = new ArrayList<>();
+                            cm.setAllOf(targetAll);
+                        }
+                        // copy items and avoid exact duplicates (by string representation)
+                        Set<String> seen = new HashSet<>();
+                        for(Model o : targetAll) if(o != null) seen.add(o.toString());
+                        for(Model o : origAll) {
+                            if(o == null) continue;
+                            if(!seen.contains(o.toString())) {
+                                targetAll.add(o);
+                                seen.add(o.toString());
+                            }
+                        }
+                    }
+                } else {
+                    cm.parent(new RefModel(defRef));
+                }
+
+                // Prune inline empty 'object' entries from allOf to avoid redundant object entries in composed models
+                try {
+                    List<Model> allOf = cm.getAllOf();
+                    if(allOf != null) {
+                        allOf.removeIf(m -> {
+                            if(m == null) return true;
+                            if(m instanceof ModelImpl) {
+                                ModelImpl mm = (ModelImpl) m;
+                                String t = mm.getType();
+                                java.util.Map<String, ?> props = mm.getProperties();
+                                boolean isEmptyObject = "object".equals(t) && (props == null || props.isEmpty());
+                                return isEmptyObject;
+                            }
+                            return false;
+                        });
+                    }
+                } catch (Exception e) {
+                    log.debug("Error while pruning composed model allOf entries: {}", e.toString());
+                }
+
+                // put back using simple name key
+                swagger.getDefinitions().put(simpleRef, cm);
+                log.info("Attached mount refs to definition {} for mount label {}", simpleRef, label);
+            }
+        }
+    }
+
+    /**
+     * Try to discover mount-point extension argument for a node (DataSchemaNode or GroupingDefinition etc.) using reflection on effective statement
+     */
+    private String findMountPointLabel(Object node) {
+        if(node == null) return null;
+        try {
+            // try to call asEffectiveStatement() or getEffectiveStatement() reflectively (public or non-public)
+            Object eff = null;
+            // helper to try a named method (public) and then invoke it safely
+            java.util.function.BiFunction<Object, String, Object> tryInvokePublic = (obj, methodName) -> {
+                try {
+                    java.lang.reflect.Method m = obj.getClass().getMethod(methodName);
+                    try {
+                        return m.invoke(obj);
+                    } catch (IllegalAccessException | java.lang.reflect.InvocationTargetException | RuntimeException iae) {
+                        log.trace("Cannot invoke public method {} on {}: {}", methodName, obj.getClass(), iae.toString());
+                        return null;
+                    }
+                } catch (NoSuchMethodException ns) {
+                    return null;
+                }
+            };
+
+            eff = tryInvokePublic.apply(node, "asEffectiveStatement");
+            if(eff == null) eff = tryInvokePublic.apply(node, "getEffectiveStatement");
+
+            if(eff == null && !declaredAccessRestricted) {
+                // try declared (non-public) methods as a fallback; setAccessible may be blocked by Java modules
+                try {
+                    java.lang.reflect.Method dm = null;
+                    try {
+                        dm = node.getClass().getDeclaredMethod("asEffectiveStatement");
+                    } catch (NoSuchMethodException ns) {
+                        // ignore
+                    }
+                    if(dm != null) {
+                        try {
+                            dm.setAccessible(true);
+                            eff = dm.invoke(node);
+                        } catch (IllegalAccessException | java.lang.reflect.InvocationTargetException | RuntimeException iae) {
+                            log.trace("Declared access to asEffectiveStatement blocked for {}: {}", node.getClass(), iae.toString());
+                            declaredAccessRestricted = true;
+                        }
+                    }
+                } catch (Exception ex) {
+                    // ignore
+                }
+                if(eff == null && !declaredAccessRestricted) {
+                    try {
+                        java.lang.reflect.Method dm2 = null;
+                        try {
+                            dm2 = node.getClass().getDeclaredMethod("getEffectiveStatement");
+                        } catch (NoSuchMethodException ns2) {
+                            // ignore
+                        }
+                        if(dm2 != null) {
+                            try {
+                                dm2.setAccessible(true);
+                                eff = dm2.invoke(node);
+                            } catch (IllegalAccessException | java.lang.reflect.InvocationTargetException | RuntimeException iae) {
+                                log.trace("Declared access to getEffectiveStatement blocked for {}: {}", node.getClass(), iae.toString());
+                                declaredAccessRestricted = true;
+                            }
+                        }
+                    } catch (Exception ex2) {
+                        // ignore
+                    }
+                }
+            }
+
+            if(eff == null) return null;
+
+            // collect potential collection-like holders (public methods, declared methods and declared fields)
+            List<Collection<?>> candidateCols = new ArrayList<>();
+
+            // helper to add values from maps or collections
+            java.util.function.Consumer<Object> addPossibleCollection = (obj) -> {
+                if(obj == null) return;
+                if(obj instanceof Collection) {
+                    candidateCols.add((Collection<?>) obj);
+                } else if(obj instanceof Map) {
+                    Map<?,?> m = (Map<?,?>) obj;
+                    for(Object v : m.values()) {
+                        if(v instanceof Collection) candidateCols.add((Collection<?>) v);
+                        else candidateCols.add(Collections.singletonList(v));
+                    }
+                } else if(obj.getClass().isArray()) {
+                    Object[] arr = (Object[]) obj;
+                    candidateCols.add(Arrays.asList(arr));
+                } else {
+                    // single item -> wrap into collection
+                    candidateCols.add(Collections.singletonList(obj));
+                }
+            };
+
+            // public methods
+            for(java.lang.reflect.Method method : eff.getClass().getMethods()) {
+                try {
+                    Class<?> rt = method.getReturnType();
+                    if(java.util.Collection.class.isAssignableFrom(rt) || java.util.Map.class.isAssignableFrom(rt) || rt.isArray()) {
+                        method.setAccessible(true);
+                        Object res = null;
+                        try {
+                            res = method.invoke(eff);
+                        } catch (IllegalAccessException | java.lang.reflect.InvocationTargetException iae) {
+                            // if access is blocked, mark restriction and skip declared access attempts later
+                            log.trace("Public method invocation blocked for {}#{}: {}", eff.getClass(), method.getName(), iae.toString());
+                            declaredAccessRestricted = true;
+                            continue;
+                        }
+                        addPossibleCollection.accept(res);
+                    }
+                } catch (Exception ex) {
+                    // ignore this method
+                }
+            }
+
+            // declared (possibly non-public) methods
+            if(!declaredAccessRestricted) {
+                for(java.lang.reflect.Method method : eff.getClass().getDeclaredMethods()) {
+                    try {
+                        Class<?> rt = method.getReturnType();
+                        if(java.util.Collection.class.isAssignableFrom(rt) || java.util.Map.class.isAssignableFrom(rt) || rt.isArray()) {
+                            method.setAccessible(true);
+                            Object res = null;
+                            try {
+                                res = method.invoke(eff);
+                            } catch (IllegalAccessException | java.lang.reflect.InvocationTargetException iae) {
+                                log.trace("Declared method invocation blocked for {}#{}: {}", eff.getClass(), method.getName(), iae.toString());
+                                declaredAccessRestricted = true;
+                                break; // stop trying declared methods
+                            }
+                            addPossibleCollection.accept(res);
+                        }
+                    } catch (Exception ex) {
+                        // ignore
+                    }
+                }
+            }
+
+            // declared fields (some implementations keep sub-statements in private fields)
+            if(!declaredAccessRestricted) {
+                for(java.lang.reflect.Field f : eff.getClass().getDeclaredFields()) {
+                    try {
+                        Class<?> ft = f.getType();
+                        if(java.util.Collection.class.isAssignableFrom(ft) || java.util.Map.class.isAssignableFrom(ft) || ft.isArray()) {
+                            f.setAccessible(true);
+                            Object res = null;
+                            try {
+                                res = f.get(eff);
+                            } catch (IllegalAccessException iae) {
+                                log.trace("Declared field access blocked for {}#{}: {}", eff.getClass(), f.getName(), iae.toString());
+                                declaredAccessRestricted = true;
+                                break;
+                            }
+                            addPossibleCollection.accept(res);
+                        }
+                    } catch (Exception ex) {
+                        // ignore
+                    }
+                }
+            }
+
+            // iterate collected sub-statement collections and look for mount-point tokens
+            for(Collection<?> col : candidateCols) {
+                if(col == null) continue;
+                for(Object item : col) {
+                    if(item == null) continue;
+                    String text = item.toString().toLowerCase();
+                    if(text.contains("mount-point") || text.contains("yangmnt:mount-point") || text.contains("yangmnt:mount_point")) {
+                        // try to get argument via methods on item (try declared methods too)
+                        String arg = tryGetStringProperty(item, new String[]{"getArgument","getArg","getValue","getArgumentValue","getLabel","getName"});
+                        if(arg != null && !arg.isEmpty()) return arg;
+
+                        // try declared methods as fallback for non-public item types
+                        if(!declaredAccessRestricted) {
+                            for(String nm : new String[]{"getArgument","getArg","getValue","getArgumentValue","getLabel","getName"}) {
+                                try {
+                                    java.lang.reflect.Method dm = item.getClass().getDeclaredMethod(nm);
+                                    dm.setAccessible(true);
+                                    Object v = dm.invoke(item);
+                                    if(v != null) return v.toString();
+                                } catch (IllegalAccessException iae) {
+                                    log.trace("Declared access blocked for item method {} of {}: {}", nm, item.getClass(), iae.toString());
+                                    declaredAccessRestricted = true;
+                                    break;
+                                } catch (Exception e) {
+                                    // ignore
+                                }
+                            }
+                        }
+
+                        // fallback: try to parse token after 'mount-point' in toString
+                        int idx = text.indexOf("mount-point");
+                        if(idx >= 0) {
+                            String after = text.substring(idx);
+                            // crude parse
+                            java.util.regex.Matcher mm = java.util.regex.Pattern.compile("mount[-_]point\\s+([a-zA-Z0-9_-]+)").matcher(after);
+                            if(mm.find()) return mm.group(1);
+                        }
+                    }
+                }
+            }
+
+        } catch (java.lang.reflect.InaccessibleObjectException iae) {
+            // access blocked by JVM/module system: avoid noisy error logs and mark restriction
+            log.trace("Reflective access to effective statement blocked for node class {}: {}", node.getClass(), iae.toString());
+            declaredAccessRestricted = true;
+            return null;
+        } catch (Exception e) {
+            // ignore and return null
+            log.debug("Error while inspecting node for mount-point: {}", e.toString());
+        }
+        return null;
+    }
+
+    private String tryGetStringProperty(Object obj, String[] candidates) {
+        for(String name : candidates) {
+            try {
+                java.lang.reflect.Method m = obj.getClass().getMethod(name);
+                Object v = m.invoke(obj);
+                if(v != null) return v.toString();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        return null;
+    }
+
+    private String getNodeId(DataNodeContainer node) {
+        if(node instanceof org.opendaylight.yangtools.yang.model.api.SchemaNode) {
+            try {
+                return ((org.opendaylight.yangtools.yang.model.api.SchemaNode)node).getQName().getLocalName();
+            } catch (Exception e) { /* ignore */ }
+        }
+        if(node instanceof org.opendaylight.yangtools.yang.model.api.Module) {
+            return ((org.opendaylight.yangtools.yang.model.api.Module)node).getName();
+        }
+        return node.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends org.opendaylight.yangtools.yang.model.api.SchemaNode & org.opendaylight.yangtools.yang.model.api.DataNodeContainer> String resolveDefinition(DataNodeContainer node) {
+        // DataObjectRepo#getDefinitionRef expects a type that is both SchemaNode and DataNodeContainer.
+        if(node == null) return null;
+        if(!(node instanceof org.opendaylight.yangtools.yang.model.api.SchemaNode)) return null;
+        try {
+            // unchecked cast to intersection generic expected by DataObjectRepo
+            return dataRepo.getDefinitionRef((T) node);
+        } catch (ClassCastException e) {
+            // if the node isn't the exact expected shape, return null
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends org.opendaylight.yangtools.yang.model.api.SchemaNode & org.opendaylight.yangtools.yang.model.api.DataNodeContainer>
+    String getNameUnchecked(Object o) {
+        return dataRepo.getName((T) o);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends org.opendaylight.yangtools.yang.model.api.SchemaNode & org.opendaylight.yangtools.yang.model.api.DataNodeContainer>
+    void addModelUnchecked(DataObjectBuilder builder, Object o, String name) {
+        builder.addModel((T) o, name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends org.opendaylight.yangtools.yang.model.api.SchemaNode & org.opendaylight.yangtools.yang.model.api.DataNodeContainer>
+    void addModelUnchecked(DataObjectBuilder builder, Object o) {
+        builder.addModel((T) o);
+    }
+}

--- a/swagger-generator/src/test/java/com/mrv/yangtools/codegen/issues/Issue45.java
+++ b/swagger-generator/src/test/java/com/mrv/yangtools/codegen/issues/Issue45.java
@@ -1,0 +1,77 @@
+package com.mrv.yangtools.codegen.issues;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.mrv.yangtools.codegen.AbstractItTest;
+import com.mrv.yangtools.codegen.SwaggerGenerator;
+import com.mrv.yangtools.common.ContextHelper;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.RefModel;
+import org.junit.Test;
+import org.junit.Assert;
+import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
+import org.opendaylight.yangtools.yang.model.api.Module;
+import org.opendaylight.yangtools.yang.parser.spi.meta.ReactorException;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Issue45 extends AbstractItTest {
+
+    @Test
+    public void testIssue45() throws IOException, ReactorException {
+        runSwaggerGeneratorWithMountMappings();
+
+        StringWriter writer = new StringWriter();
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.writeValue(writer, swagger);
+
+        ComposedModel specificConfig = (ComposedModel) swagger.getDefinitions().get("list.manager.listentry.SpecificConfig");
+        Assert.assertEquals("entry.type._1.Content", ((RefModel) specificConfig.getAllOf().get(0)).getSimpleRef());
+        Assert.assertEquals("entry.type._2.Content", ((RefModel) specificConfig.getAllOf().get(1)).getSimpleRef());
+
+        String yaml = writer.toString();
+
+        try (PrintWriter out = new PrintWriter("swagger.yml")) {
+            out.print(yaml);
+        }
+    }
+
+    private void runSwaggerGeneratorWithMountMappings() throws ReactorException {
+        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:*.yang");
+        final EffectiveModelContext context = buildEffectiveModelContext(
+                Paths.get("src","test","resources","bug_45").toString(),
+                p -> matcher.matches(p.getFileName()));
+
+        Collection<? extends Module> modulesToGenerate = context.getModules().stream()
+                .filter(module -> module.getName().equals("list-manager")
+                        || module.getName().equals("entry-type-1"))
+                .collect(Collectors.toList());
+
+        SwaggerGenerator generator = new SwaggerGenerator(context, modulesToGenerate).defaultConfig();
+        Map<String, List<String>> mapping = new HashMap<>();
+        mapping.put("list-entry-data", Arrays.asList("entry-type-1:content", "entry-type-2:content"));
+        generator.yangmntMappings(mapping);
+        swagger = generator.generate();
+    }
+
+    private EffectiveModelContext buildEffectiveModelContext(String dir, Predicate<Path> accept)
+            throws ReactorException {
+        return ContextHelper.getFromDir(Stream.of(FileSystems.getDefault().getPath(dir)), accept);
+    }
+}

--- a/swagger-generator/src/test/resources/bug_45/entry-type-1.yang
+++ b/swagger-generator/src/test/resources/bug_45/entry-type-1.yang
@@ -1,0 +1,22 @@
+module entry-type-1 {
+    namespace "urn:demo:entry-type-1";
+    prefix "et1";
+    yang-version 1.1;
+    revision "2022-03-12" {
+        description "First cut";
+    }
+    grouping content {
+        container type-1 {
+            leaf x {
+                type string;
+            }
+            leaf y {
+                type string;
+            }
+            leaf z {
+                type string;
+            }
+        }
+    }
+    uses content;
+}

--- a/swagger-generator/src/test/resources/bug_45/entry-type-2.yang
+++ b/swagger-generator/src/test/resources/bug_45/entry-type-2.yang
@@ -1,0 +1,22 @@
+module entry-type-2 {
+    namespace "urn:demo:entry-type-2";
+    prefix "et2";
+    yang-version 1.1;
+    revision "2022-03-12" {
+        description "First cut";
+    }
+    grouping content {
+        container type-2 {
+            leaf a {
+                type string;
+            }
+            leaf b {
+                type string;
+            }
+            leaf c {
+                type string;
+            }
+        }
+    }
+    uses content;
+}

--- a/swagger-generator/src/test/resources/bug_45/ietf-datastores.yang
+++ b/swagger-generator/src/test/resources/bug_45/ietf-datastores.yang
@@ -1,0 +1,90 @@
+module ietf-datastores {
+	yang-version 1.1;
+    namespace
+        "urn:ietf:params:xml:ns:yang:ietf-datastores";
+
+    prefix ds;
+
+    organization
+        "IETF Network Modeling (NETMOD) Working Group";
+
+    contact
+        "WG Web: <https://datatracker.ietf.org/wg/netmod/> WG List: <mailto:netmod@ietf.org>
+        Author: Martin Bjorklund <mailto:mbj@tail-f.com> Author: Juergen
+        Schoenwaelder <mailto:j.schoenwaelder@jacobs-university.de> Author:
+        Phil Shafer <mailto:phil@juniper.net> Author: Kent Watsen <mailto:kwatsen@juniper.net>
+        Author: Rob Wilton <rwilton@cisco.com>";
+
+    description
+        "This YANG module defines a set of identities for identifying
+        datastores. Copyright (c) 2018 IETF Trust and the persons identified
+        as authors of the code. All rights reserved. Redistribution and
+        use in source and binary forms, with or without modification,
+        is permitted pursuant to, and subject to the license terms contained
+        in, the Simplified BSD License set forth in Section 4.c of the
+        IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info).
+        This version of this YANG module is part of RFC 8342 (https://www.rfc-editor.org/info/rfc8342);
+        see the RFC itself for full legal notices.";
+
+    revision "2018-02-14" {
+        description "Initial revision.";
+        reference
+                "RFC 8342: Network Management Datastore Architecture (NMDA)";
+    }
+
+    identity datastore {
+        description
+                "Abstract base identity for datastore identities.";
+    }
+
+    identity conventional {
+        base datastore;
+        description
+                "Abstract base identity for conventional configuration datastores.";
+    }
+
+    identity running {
+        base conventional;
+        description
+                "The running configuration datastore.";
+    }
+
+    identity candidate {
+        base conventional;
+        description
+                "The candidate configuration datastore.";
+    }
+
+    identity startup {
+        base conventional;
+        description
+                "The startup configuration datastore.";
+    }
+
+    identity intended {
+        base conventional;
+        description
+                "The intended configuration datastore.";
+    }
+
+    identity dynamic {
+        base datastore;
+        description
+                "Abstract base identity for dynamic configuration datastores.";
+    }
+
+    identity operational {
+        base datastore;
+        description
+                "The operational state datastore.";
+    }
+
+    typedef datastore-ref {
+        type identityref {
+            base datastore;
+        }
+        description
+                "A datastore identity reference.";
+    }
+}
+// module ietf-datastores

--- a/swagger-generator/src/test/resources/bug_45/ietf-inet-types.yang
+++ b/swagger-generator/src/test/resources/bug_45/ietf-inet-types.yang
@@ -1,0 +1,454 @@
+ module ietf-inet-types {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+
+    prefix inet;
+
+    organization
+      "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+    contact
+      "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+    description
+      "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+    revision "2013-07-15" {
+      description
+        "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+      reference
+        "RFC 6991: Common YANG Data Types";
+
+    }
+
+    revision "2010-09-24" {
+      description "Initial revision.";
+      reference
+        "RFC 6021: Common YANG Data Types";
+
+    }
+
+
+    typedef ip-version {
+      type enumeration {
+        enum "unknown" {
+          value 0;
+          description
+            "An unknown or unspecified version of the Internet
+          protocol.";
+        }
+        enum "ipv4" {
+          value 1;
+          description
+            "The IPv4 protocol as defined in RFC 791.";
+        }
+        enum "ipv6" {
+          value 2;
+          description
+            "The IPv6 protocol as defined in RFC 2460.";
+        }
+      }
+      description
+        "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+      reference
+        "RFC  791: Internet Protocol
+         RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+         RFC 4001: Textual Conventions for Internet Network Addresses";
+
+    }
+
+    typedef dscp {
+      type uint8 {
+        range "0..63";
+      }
+      description
+        "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+      reference
+        "RFC 3289: Management Information Base for the Differentiated
+        	  Services Architecture
+         RFC 2474: Definition of the Differentiated Services Field
+        	  (DS Field) in the IPv4 and IPv6 Headers
+         RFC 2780: IANA Allocation Guidelines For Values In
+        	  the Internet Protocol and Related Headers";
+
+    }
+
+    typedef ipv6-flow-label {
+      type uint32 {
+        range "0..1048575";
+      }
+      description
+        "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+      reference
+        "RFC 3595: Textual Conventions for IPv6 Flow Label
+         RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+
+    }
+
+    typedef port-number {
+      type uint16 {
+        range "0..65535";
+      }
+      description
+        "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+      reference
+        "RFC  768: User Datagram Protocol
+         RFC  793: Transmission Control Protocol
+         RFC 4960: Stream Control Transmission Protocol
+         RFC 4340: Datagram Congestion Control Protocol (DCCP)
+         RFC 4001: Textual Conventions for Internet Network Addresses";
+
+    }
+
+    typedef as-number {
+      type uint32;
+      description
+        "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+      reference
+        "RFC 1930: Guidelines for creation, selection, and registration
+        	  of an Autonomous System (AS)
+         RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+         RFC 4001: Textual Conventions for Internet Network Addresses
+         RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+        	  Number Space";
+
+    }
+
+    typedef ip-address {
+      type union {
+        type ipv4-address;
+        type ipv6-address;
+      }
+      description
+        "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+      reference
+        "RFC 4007: IPv6 Scoped Address Architecture";
+
+    }
+
+    typedef ipv4-address {
+      type string {
+        pattern
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\p{N}\p{L}]+)?';
+      }
+      description
+        "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+    }
+
+    typedef ipv6-address {
+      type string {
+        pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?';
+        pattern
+          '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?';
+      }
+      description
+        "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+      reference
+        "RFC 4291: IP Version 6 Addressing Architecture
+         RFC 4007: IPv6 Scoped Address Architecture
+         RFC 5952: A Recommendation for IPv6 Address Text
+        	  Representation";
+
+    }
+
+    typedef ip-address-no-zone {
+      type union {
+        type ipv4-address-no-zone;
+        type ipv6-address-no-zone;
+      }
+      description
+        "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+      reference
+        "RFC 4007: IPv6 Scoped Address Architecture";
+
+    }
+
+    typedef ipv4-address-no-zone {
+      type ipv4-address {
+        pattern '[0-9\.]*';
+      }
+      description
+        "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    }
+
+    typedef ipv6-address-no-zone {
+      type ipv6-address {
+        pattern '[0-9a-fA-F:\.]*';
+      }
+      description
+        "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+      reference
+        "RFC 4291: IP Version 6 Addressing Architecture
+         RFC 4007: IPv6 Scoped Address Architecture
+         RFC 5952: A Recommendation for IPv6 Address Text
+        	  Representation";
+
+    }
+
+    typedef ip-prefix {
+      type union {
+        type ipv4-prefix;
+        type ipv6-prefix;
+      }
+      description
+        "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+    }
+
+    typedef ipv4-prefix {
+      type string {
+        pattern
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2]))';
+      }
+      description
+        "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+    }
+
+    typedef ipv6-prefix {
+      type string {
+        pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+        pattern
+          '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(/.+)';
+      }
+      description
+        "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+      reference
+        "RFC 5952: A Recommendation for IPv6 Address Text
+        	  Representation";
+
+    }
+
+    typedef domain-name {
+      type string {
+        length "1..253";
+        pattern
+          '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)|\.';
+      }
+      description
+        "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+      reference
+        "RFC  952: DoD Internet Host Table Specification
+         RFC 1034: Domain Names - Concepts and Facilities
+         RFC 1123: Requirements for Internet Hosts -- Application
+        	  and Support
+         RFC 2782: A DNS RR for specifying the location of services
+        	  (DNS SRV)
+         RFC 5890: Internationalized Domain Names in Applications
+        	  (IDNA): Definitions and Document Framework";
+
+    }
+
+    typedef host {
+      type union {
+        type ip-address;
+        type domain-name;
+      }
+      description
+        "The host type represents either an IP address or a DNS
+      domain name.";
+    }
+
+    typedef uri {
+      type string;
+      description
+        "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+      reference
+        "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+         RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+        	  Group: Uniform Resource Identifiers (URIs), URLs,
+        	  and Uniform Resource Names (URNs): Clarifications
+        	  and Recommendations
+         RFC 5017: MIB Textual Conventions for Uniform Resource
+        	  Identifiers (URIs)";
+
+    }
+  }  // module ietf-inet-types

--- a/swagger-generator/src/test/resources/bug_45/ietf-yang-library.yang
+++ b/swagger-generator/src/test/resources/bug_45/ietf-yang-library.yang
@@ -1,0 +1,548 @@
+module ietf-yang-library {
+     yang-version 1.1;
+     namespace "urn:ietf:params:xml:ns:yang:ietf-yang-library";
+     prefix yanglib;
+
+     import ietf-yang-types {
+       prefix yang;
+       reference
+         "RFC 6991: Common YANG Data Types";
+     }
+     import ietf-inet-types {
+       prefix inet;
+       reference
+         "RFC 6991: Common YANG Data Types";
+     }
+     import ietf-datastores {
+       prefix ds;
+       reference
+         "RFC 8342: Network Management Datastore Architecture
+                    (NMDA)";
+     }
+
+     organization
+       "IETF NETCONF (Network Configuration) Working Group";
+     contact
+       "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+        WG List:  <mailto:netconf@ietf.org>
+
+        Author:   Andy Bierman
+                  <mailto:andy@yumaworks.com>
+
+        Author:   Martin Bjorklund
+                  <mailto:mbj@tail-f.com>
+
+        Author:   Juergen Schoenwaelder
+                  <mailto:j.schoenwaelder@jacobs-university.de>
+
+        Author:   Kent Watsen
+                  <mailto:kent+ietf@watsen.net>
+
+        Author:   Robert Wilton
+                  <mailto:rwilton@cisco.com>";
+     description
+       "This module provides information about the YANG modules,
+        datastores, and datastore schemas used by a network
+        management server.
+		The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+        NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+        'MAY', and 'OPTIONAL' in this document are to be interpreted as
+        described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+        they appear in all capitals, as shown here.
+
+        Copyright (c) 2019 IETF Trust and the persons identified as
+        authors of the code.  All rights reserved.
+
+        Redistribution and use in source and binary forms, with or
+        without modification, is permitted pursuant to, and subject
+        to the license terms contained in, the Simplified BSD License
+        set forth in Section 4.c of the IETF Trust's Legal Provisions
+        Relating to IETF Documents
+        (https://trustee.ietf.org/license-info).
+
+        This version of this YANG module is part of RFC 8525; see
+        the RFC itself for full legal notices.";
+
+     revision 2019-01-04 {
+       description
+         "Added support for multiple datastores according to the
+          Network Management Datastore Architecture (NMDA).";
+       reference
+         "RFC 8525: YANG Library";
+     }
+     revision 2016-04-09 {
+       description
+         "Initial revision.";
+       reference
+         "RFC 7895: YANG Module Library";
+     }
+
+     /*
+      * Typedefs
+      */
+
+     typedef revision-identifier {
+       type string {
+         pattern '\d{4}-\d{2}-\d{2}';
+       }
+       description
+         "Represents a specific date in YYYY-MM-DD format.";
+     }
+
+     /*
+      * Groupings
+      */
+	  grouping module-identification-leafs {
+       description
+         "Parameters for identifying YANG modules and submodules.";
+       leaf name {
+         type yang:yang-identifier;
+         mandatory true;
+         description
+           "The YANG module or submodule name.";
+       }
+       leaf revision {
+         type revision-identifier;
+         description
+           "The YANG module or submodule revision date.  If no revision
+            statement is present in the YANG module or submodule, this
+            leaf is not instantiated.";
+       }
+     }
+
+     grouping location-leaf-list {
+       description
+         "Common leaf-list parameter for the locations of modules and
+          submodules.";
+       leaf-list location {
+         type inet:uri;
+         description
+           "Contains a URL that represents the YANG schema
+            resource for this module or submodule.
+
+            This leaf will only be present if there is a URL
+            available for retrieval of the schema for this entry.";
+       }
+     }
+
+     grouping module-implementation-parameters {
+       description
+         "Parameters for describing the implementation of a module.";
+       leaf-list feature {
+         type yang:yang-identifier;
+         description
+           "List of all YANG feature names from this module that are
+            supported by the server, regardless whether they are defined
+            in the module or any included submodule.";
+       }
+       leaf-list deviation {
+         type leafref {
+           path "../../module/name";
+         }
+
+		 description
+           "List of all YANG deviation modules used by this server to
+            modify the conformance of the module associated with this
+            entry.  Note that the same module can be used for deviations
+            for multiple modules, so the same entry MAY appear within
+            multiple 'module' entries.
+
+            This reference MUST NOT (directly or indirectly)
+            refer to the module being deviated.
+
+            Robust clients may want to make sure that they handle a
+            situation where a module deviates itself (directly or
+            indirectly) gracefully.";
+       }
+     }
+
+     grouping module-set-parameters {
+       description
+         "A set of parameters that describe a module set.";
+       leaf name {
+         type string;
+         description
+           "An arbitrary name of the module set.";
+       }
+       list module {
+         key "name";
+         description
+           "An entry in this list represents a module implemented by the
+            server, as per Section 5.6.5 of RFC 7950, with a particular
+            set of supported features and deviations.";
+         reference
+           "RFC 7950: The YANG 1.1 Data Modeling Language";
+         uses module-identification-leafs;
+         leaf namespace {
+           type inet:uri;
+           mandatory true;
+           description
+             "The XML namespace identifier for this module.";
+         }
+         uses location-leaf-list;
+         list submodule {
+           key "name";
+           description
+             "Each entry represents one submodule within the
+              parent module.";
+           uses module-identification-leafs;
+           uses location-leaf-list;
+         }
+
+		 uses module-implementation-parameters;
+       }
+       list import-only-module {
+         key "name revision";
+         description
+           "An entry in this list indicates that the server imports
+            reusable definitions from the specified revision of the
+            module but does not implement any protocol-accessible
+            objects from this revision.
+
+            Multiple entries for the same module name MAY exist.  This
+            can occur if multiple modules import the same module but
+            specify different revision dates in the import statements.";
+         leaf name {
+           type yang:yang-identifier;
+           description
+             "The YANG module name.";
+         }
+         leaf revision {
+           type union {
+             type revision-identifier;
+             type string {
+               length "0";
+             }
+           }
+           description
+             "The YANG module revision date.
+              A zero-length string is used if no revision statement
+              is present in the YANG module.";
+         }
+         leaf namespace {
+           type inet:uri;
+           mandatory true;
+           description
+             "The XML namespace identifier for this module.";
+         }
+         uses location-leaf-list;
+         list submodule {
+           key "name";
+           description
+             "Each entry represents one submodule within the
+              parent module.";
+           uses module-identification-leafs;
+           uses location-leaf-list;
+         }
+       }
+     }
+
+	 grouping yang-library-parameters {
+       description
+         "The YANG library data structure is represented as a grouping
+          so it can be reused in configuration or another monitoring
+          data structure.";
+       list module-set {
+         key "name";
+         description
+           "A set of modules that may be used by one or more schemas.
+
+            A module set does not have to be referentially complete,
+            i.e., it may define modules that contain import statements
+            for other modules not included in the module set.";
+         uses module-set-parameters;
+       }
+       list schema {
+         key "name";
+         description
+           "A datastore schema that may be used by one or more
+            datastores.
+
+            The schema must be valid and referentially complete, i.e.,
+            it must contain modules to satisfy all used import
+            statements for all modules specified in the schema.";
+         leaf name {
+           type string;
+           description
+             "An arbitrary name of the schema.";
+         }
+         leaf-list module-set {
+           type leafref {
+             path "../../module-set/name";
+           }
+           description
+             "A set of module-sets that are included in this schema.
+              If a non-import-only module appears in multiple module
+              sets, then the module revision and the associated features
+              and deviations must be identical.";
+         }
+       }
+       list datastore {
+         key "name";
+         description
+           "A datastore supported by this server.
+
+            Each datastore indicates which schema it supports.
+
+			The server MUST instantiate one entry in this list per
+            specific datastore it supports.
+            Each datastore entry with the same datastore schema SHOULD
+            reference the same schema.";
+         leaf name {
+           type ds:datastore-ref;
+           description
+             "The identity of the datastore.";
+         }
+         leaf schema {
+           type leafref {
+             path "../../schema/name";
+           }
+           mandatory true;
+           description
+             "A reference to the schema supported by this datastore.
+              All non-import-only modules of the schema are implemented
+              with their associated features and deviations.";
+         }
+       }
+     }
+
+     /*
+      * Top-level container
+      */
+
+     container yang-library {
+       config false;
+       description
+         "Container holding the entire YANG library of this server.";
+       uses yang-library-parameters;
+       leaf content-id {
+         type string;
+         mandatory true;
+         description
+           "A server-generated identifier of the contents of the
+            '/yang-library' tree.  The server MUST change the value of
+            this leaf if the information represented by the
+            '/yang-library' tree, except '/yang-library/content-id', has
+            changed.";
+       }
+     }
+
+     /*
+      * Notifications
+      */
+
+     notification yang-library-update {
+		description
+         "Generated when any YANG library information on the
+          server has changed.";
+       leaf content-id {
+         type leafref {
+           path "/yanglib:yang-library/yanglib:content-id";
+         }
+         mandatory true;
+         description
+           "Contains the YANG library content identifier for the updated
+            YANG library at the time the notification is generated.";
+       }
+     }
+
+     /*
+      * Legacy groupings
+      */
+
+     grouping module-list {
+       status deprecated;
+       description
+         "The module data structure is represented as a grouping
+          so it can be reused in configuration or another monitoring
+          data structure.";
+
+       grouping common-leafs {
+         status deprecated;
+         description
+           "Common parameters for YANG modules and submodules.";
+         leaf name {
+           type yang:yang-identifier;
+           status deprecated;
+           description
+             "The YANG module or submodule name.";
+         }
+         leaf revision {
+           type union {
+             type revision-identifier;
+             type string {
+               length "0";
+             }
+           }
+           status deprecated;
+           description
+             "The YANG module or submodule revision date.
+              A zero-length string is used if no revision statement
+              is present in the YANG module or submodule.";
+         }
+
+		 }
+
+       grouping schema-leaf {
+         status deprecated;
+         description
+           "Common schema leaf parameter for modules and submodules.";
+         leaf schema {
+           type inet:uri;
+           description
+             "Contains a URL that represents the YANG schema
+              resource for this module or submodule.
+
+              This leaf will only be present if there is a URL
+              available for retrieval of the schema for this entry.";
+         }
+       }
+       list module {
+         key "name revision";
+         status deprecated;
+         description
+           "Each entry represents one revision of one module
+            currently supported by the server.";
+         uses common-leafs {
+           status deprecated;
+         }
+         uses schema-leaf {
+           status deprecated;
+         }
+         leaf namespace {
+           type inet:uri;
+           mandatory true;
+           status deprecated;
+           description
+             "The XML namespace identifier for this module.";
+         }
+         leaf-list feature {
+           type yang:yang-identifier;
+           status deprecated;
+           description
+             "List of YANG feature names from this module that are
+              supported by the server, regardless of whether they are
+              defined in the module or any included submodule.";
+         }
+         list deviation {
+           key "name revision";
+           status deprecated;
+
+		   description
+             "List of YANG deviation module names and revisions
+              used by this server to modify the conformance of
+              the module associated with this entry.  Note that
+              the same module can be used for deviations for
+              multiple modules, so the same entry MAY appear
+              within multiple 'module' entries.
+
+              The deviation module MUST be present in the 'module'
+              list, with the same name and revision values.
+              The 'conformance-type' value will be 'implement' for
+              the deviation module.";
+           uses common-leafs {
+             status deprecated;
+           }
+         }
+         leaf conformance-type {
+           type enumeration {
+             enum implement {
+               description
+                 "Indicates that the server implements one or more
+                  protocol-accessible objects defined in the YANG module
+                  identified in this entry.  This includes deviation
+                  statements defined in the module.
+
+                  For YANG version 1.1 modules, there is at most one
+                  'module' entry with conformance type 'implement' for a
+                  particular module name, since YANG 1.1 requires that
+                  at most one revision of a module is implemented.
+
+                  For YANG version 1 modules, there SHOULD NOT be more
+                  than one 'module' entry for a particular module
+                  name.";
+             }
+             enum import {
+               description
+                 "Indicates that the server imports reusable definitions
+                  from the specified revision of the module but does
+                  not implement any protocol-accessible objects from
+                  this revision.
+
+                  Multiple 'module' entries for the same module name MAY
+                  exist.  This can occur if multiple modules import the
+                  same module but specify different revision dates in
+                  the import statements.";
+             }
+           }
+           mandatory true;
+
+		   status deprecated;
+           description
+             "Indicates the type of conformance the server is claiming
+              for the YANG module identified by this entry.";
+         }
+         list submodule {
+           key "name revision";
+           status deprecated;
+           description
+             "Each entry represents one submodule within the
+              parent module.";
+           uses common-leafs {
+             status deprecated;
+           }
+           uses schema-leaf {
+             status deprecated;
+           }
+         }
+       }
+     }
+
+     /*
+      * Legacy operational state data nodes
+      */
+
+     container modules-state {
+       config false;
+       status deprecated;
+       description
+         "Contains YANG module monitoring information.";
+       leaf module-set-id {
+         type string;
+         mandatory true;
+         status deprecated;
+         description
+           "Contains a server-specific identifier representing
+            the current set of modules and submodules.  The
+            server MUST change the value of this leaf if the
+            information represented by the 'module' list instances
+            has changed.";
+       }
+       uses module-list {
+         status deprecated;
+       }
+     }
+
+     /*
+      * Legacy notifications
+	  */
+
+     notification yang-library-change {
+       status deprecated;
+       description
+         "Generated when the set of modules and submodules supported
+          by the server has changed.";
+       leaf module-set-id {
+         type leafref {
+           path "/yanglib:modules-state/yanglib:module-set-id";
+         }
+         mandatory true;
+         status deprecated;
+         description
+           "Contains the module-set-id value representing the
+            set of modules and submodules supported at the server
+            at the time the notification is generated.";
+       }
+     }
+   }
+

--- a/swagger-generator/src/test/resources/bug_45/ietf-yang-schema-mount.yang
+++ b/swagger-generator/src/test/resources/bug_45/ietf-yang-schema-mount.yang
@@ -1,0 +1,256 @@
+module ietf-yang-schema-mount {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-schema-mount";
+  prefix yangmnt;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  import ietf-yang-library {
+    prefix yanglib;
+    reference
+      "RFC 7895: YANG Module Library";
+  }
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <https://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Ladislav Lhotka
+               <mailto:lhotka@nic.cz>";
+
+  description
+    "This module defines a YANG extension statement that can be used
+     to incorporate data models defined in other YANG modules in a
+     module. It also defines operational state data that specify the
+     overall structure of the data model.
+
+     Copyright (c) 2017 IETF Trust and the persons identified as
+     authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'MAY', and
+     'OPTIONAL' in the module text are to be interpreted as described
+     in RFC 2119 (https://tools.ietf.org/html/rfc2119).
+
+     This version of this YANG module is part of RFC XXXX
+     (https://tools.ietf.org/html/rfcXXXX); see the RFC itself for
+     full legal notices.";
+
+  revision 2017-10-09 {
+    description
+      "Initial revision.";
+    reference
+      "RFC XXXX: YANG Schema Mount";
+  }
+
+  /*
+   * Extensions
+   */
+
+  extension mount-point {
+    argument label;
+    description
+      "The argument 'label' is a YANG identifier, i.e., it is of the
+       type 'yang:yang-identifier'.
+
+       The 'mount-point' statement MUST NOT be used in a YANG
+       version 1 module, neither explicitly nor via a 'uses'
+       statement.
+
+       The 'mount-point' statement MAY be present as a substatement
+       of 'container' and 'list', and MUST NOT be present elsewhere.
+       There MUST NOT be more than one 'mount-point' statement in a
+       given 'container' or 'list' statement.
+
+       If a mount point is defined within a grouping, its label is
+       bound to the module where the grouping is used.
+
+       A mount point defines a place in the node hierarchy where
+       other data models may be attached. A server that implements a
+       module with a mount point populates the
+       /schema-mounts/mount-point list with detailed information on
+       which data models are mounted at each mount point.
+
+       Note that the 'mount-point' statement does not define a new
+       data node.";
+  }
+
+  /*
+   * Groupings
+   */
+
+  grouping mount-point-list {
+    description
+      "This grouping is used inside the 'schema-mounts' container and
+       inside the 'schema' list.";
+    list mount-point {
+      key "module label";
+      description
+        "Each entry of this list specifies a schema for a particular
+         mount point.
+
+         Each mount point MUST be defined using the 'mount-point'
+         extension in one of the modules listed in the corresponding
+         YANG library instance with conformance type 'implement'. The
+         corresponding YANG library instance is:
+
+         - standard YANG library state data as defined in RFC 7895,
+           if the 'mount-point' list is a child of 'schema-mounts',
+
+         - the contents of the sibling 'yanglib:modules-state'
+           container, if the 'mount-point' list is a child of
+           'schema'.";
+      leaf module {
+        type yang:yang-identifier;
+        description
+          "Name of a module containing the mount point.";
+      }
+      leaf label {
+        type yang:yang-identifier;
+        description
+          "Label of the mount point defined using the 'mount-point'
+           extension.";
+      }
+      leaf config {
+        type boolean;
+        default "true";
+        description
+          "If this leaf is set to 'false', then all data nodes in the
+           mounted schema are read-only (config false), regardless of
+           their 'config' property.";
+      }
+      choice schema-ref {
+        mandatory true;
+        description
+          "Alternatives for specifying the schema.";
+        leaf inline {
+          type empty;
+          description
+            "This leaf indicates that the server has mounted
+             'ietf-yang-library' and 'ietf-schema-mount' at the mount
+             point, and their instantiation (i.e., state data
+             containers 'yanglib:modules-state' and 'schema-mounts')
+             provides the information about the mounted schema.";
+        }
+        list use-schema {
+          key "name";
+          min-elements 1;
+          description
+            "Each entry of this list contains a reference to a schema
+             defined in the /schema-mounts/schema list.";
+          leaf name {
+            type leafref {
+              path "/schema-mounts/schema/name";
+            }
+            description
+              "Name of the referenced schema.";
+          }
+          leaf-list parent-reference {
+            type yang:xpath1.0;
+            description
+              "Entries of this leaf-list are XPath 1.0 expressions
+               that are evaluated in the following context:
+
+               - The context node is the node in the parent data tree
+                 where the mount-point is defined.
+
+               - The accessible tree is the parent data tree
+                 *without* any nodes defined in modules that are
+                 mounted inside the parent schema.
+
+               - The context position and context size are both equal
+                 to 1.
+
+               - The set of variable bindings is empty.
+
+               - The function library is the core function library
+                 defined in [XPath] and the functions defined in
+                 Section 10 of [RFC7950].
+
+               - The set of namespace declarations is defined by the
+                 'namespace' list under 'schema-mounts'.
+
+               Each XPath expression MUST evaluate to a nodeset
+               (possibly empty). For the purposes of evaluating XPath
+               expressions whose context nodes are defined in the
+               mounted schema, the union of all these nodesets
+               together with ancestor nodes are added to the
+               accessible data tree.";
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   * State data nodes
+   */
+
+  container schema-mounts {
+    config false;
+    description
+      "Contains information about the structure of the overall
+       mounted data model implemented in the server.";
+    list namespace {
+      key "prefix";
+      description
+        "This list provides a mapping of namespace prefixes that are
+         used in XPath expressions of 'parent-reference' leafs to the
+         corresponding namespace URI references.";
+      leaf prefix {
+        type yang:yang-identifier;
+        description
+          "Namespace prefix.";
+      }
+      leaf uri {
+        type inet:uri;
+        description
+          "Namespace URI reference.";
+      }
+    }
+    uses mount-point-list;
+    list schema {
+      key "name";
+      description
+        "Each entry specifies a schema that can be mounted at a mount
+         point.  The schema information consists of two parts:
+
+         - an instance of YANG library that defines YANG modules used
+           in the schema,
+
+         - mount-point list with content identical to the top-level
+           mount-point list (this makes the schema structure
+           recursive).";
+      leaf name {
+        type string;
+        description
+          "Arbitrary name of the schema entry.";
+      }
+      uses yanglib:module-list;
+      uses mount-point-list;
+    }
+  }
+}

--- a/swagger-generator/src/test/resources/bug_45/ietf-yang-types.yang
+++ b/swagger-generator/src/test/resources/bug_45/ietf-yang-types.yang
@@ -1,0 +1,489 @@
+module ietf-yang-types {
+
+    yang-version 1;
+
+    namespace
+      "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+
+    prefix yang;
+
+    organization
+      "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+    contact
+      "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+    description
+      "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+    revision "2013-07-15" {
+      description
+        "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+      reference
+        "RFC 6991: Common YANG Data Types";
+
+    }
+
+    revision "2010-09-24" {
+      description "Initial revision.";
+      reference
+        "RFC 6021: Common YANG Data Types";
+
+    }
+
+
+    typedef counter32 {
+      type uint32;
+      description
+        "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+      reference
+        "RFC 2578: Structure of Management Information Version 2
+        	  (SMIv2)";
+
+    }
+
+    typedef zero-based-counter32 {
+      type counter32;
+      default "0";
+      description
+        "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+      reference
+        "RFC 4502: Remote Network Monitoring Management Information
+        	  Base Version 2";
+
+    }
+
+    typedef counter64 {
+      type uint64;
+      description
+        "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+      reference
+        "RFC 2578: Structure of Management Information Version 2
+        	  (SMIv2)";
+
+    }
+
+    typedef zero-based-counter64 {
+      type counter64;
+      default "0";
+      description
+        "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+
+
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+      reference
+        "RFC 2856: Textual Conventions for Additional High Capacity
+        	  Data Types";
+
+    }
+
+    typedef gauge32 {
+      type uint32;
+      description
+        "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+      reference
+        "RFC 2578: Structure of Management Information Version 2
+        	  (SMIv2)";
+
+    }
+
+    typedef gauge64 {
+      type uint64;
+      description
+        "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+      reference
+        "RFC 2856: Textual Conventions for Additional High Capacity
+        	  Data Types";
+
+    }
+
+    typedef object-identifier {
+      type string {
+        pattern
+          '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))(\.(0|([1-9]\d*)))*';
+      }
+      description
+        "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+      reference
+        "ISO9834-1: Information technology -- Open Systems
+        Interconnection -- Procedures for the operation of OSI
+        Registration Authorities: General procedures and top
+        arcs of the ASN.1 Object Identifier tree";
+
+    }
+
+    typedef object-identifier-128 {
+      type object-identifier {
+        pattern '\d*(\.\d*){1,127}';
+      }
+      description
+        "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+      reference
+        "RFC 2578: Structure of Management Information Version 2
+        	  (SMIv2)";
+
+    }
+
+    typedef yang-identifier {
+      type string {
+        length "1..max";
+        pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+        pattern
+          '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+      }
+      description
+        "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+      reference
+        "RFC 6020: YANG - A Data Modeling Language for the Network
+        	  Configuration Protocol (NETCONF)";
+
+    }
+
+    typedef date-and-time {
+      type string {
+        pattern
+          '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+\-]\d{2}:\d{2})';
+      }
+      description
+        "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+      reference
+        "RFC 3339: Date and Time on the Internet: Timestamps
+         RFC 2579: Textual Conventions for SMIv2
+        XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+
+    }
+
+    typedef timeticks {
+      type uint32;
+      description
+        "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+      reference
+        "RFC 2578: Structure of Management Information Version 2
+        	  (SMIv2)";
+
+    }
+
+    typedef timestamp {
+      type timeticks;
+      description
+        "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+      reference
+        "RFC 2579: Textual Conventions for SMIv2";
+
+    }
+
+    typedef phys-address {
+      type string {
+        pattern
+          '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+      }
+      description
+        "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+      reference
+        "RFC 2579: Textual Conventions for SMIv2";
+
+    }
+
+    typedef mac-address {
+      type string {
+        pattern
+          '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+      }
+      description
+        "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+      reference
+        "IEEE 802: IEEE Standard for Local and Metropolitan Area
+        	  Networks: Overview and Architecture
+         RFC 2579: Textual Conventions for SMIv2";
+
+    }
+
+    typedef xpath1.0 {
+      type string;
+      description
+        "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+      reference
+        "XPATH: XML Path Language (XPath) Version 1.0";
+
+    }
+
+    typedef hex-string {
+      type string {
+        pattern
+          '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+      }
+      description
+        "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+    }
+
+    typedef uuid {
+      type string {
+        pattern
+          '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+      }
+      description
+        "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+      reference
+        "RFC 4122: A Universally Unique IDentifier (UUID) URN
+        	  Namespace";
+
+    }
+
+    typedef dotted-quad {
+      type string {
+        pattern
+          '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+      }
+      description
+        "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+    }
+  }  // module ietf-yang-types

--- a/swagger-generator/src/test/resources/bug_45/list-manager.yang
+++ b/swagger-generator/src/test/resources/bug_45/list-manager.yang
@@ -1,0 +1,46 @@
+module list-manager {
+    namespace "urn:demo:list-manager";
+    prefix "lm";
+    yang-version 1.1;
+    import ietf-yang-types {prefix yang;}
+    import ietf-yang-schema-mount { prefix "yangmnt"; }
+
+    revision "2022-03-12" {
+        description "First cut";
+    }
+    typedef list-entry-status {
+        type enumeration {
+            enum active;
+            enum disabled;
+        }
+    }
+    grouping list-config-parameters {
+        leaf name {
+            type string;
+        }
+        leaf status {
+            type list-entry-status;
+        }
+    }
+    grouping list-state-attributes {
+        leaf in-use {
+            config false;
+            type boolean;
+        }
+        leaf created-at {
+            config false;
+            type yang:date-and-time;
+        }
+    }
+    list list-entry {
+        key name;
+        uses list-config-parameters;
+        uses list-state-attributes;
+        leaf entry-type {
+            type string;
+        }
+        container specific-config {
+             yangmnt:mount-point list-entry-data;
+        }
+    }
+}


### PR DESCRIPTION
Add mount-point support requested in [issue 45](https://github.com/Amartus/yang2swagger/issues/45).
Added:
 - MountPointPostProcessor which:
    - looks up mount-point labels in yang files 
    - compares those labels with types taken from yangmntMappings
    - Adds types taken from yangmntMappings to definition containing mount-point label
    - If type has not been genereated (not specified in modulesToGenerate in Swaggergenerator), type is added as definition in swagger
 - Extend SwaggerGenerator to execute MountPointPostProcessor when yangmntMappings are provided 
 - Extend Main.java do add CLI support:
    - I've tested solution with following cli command:
    `java -jar .\cli\target\swagger-generator-cli-2.1.0-executable.jar -yang-dir './swagger-generator/src/test/resources/bug_45' -mount-point-mappings '{ \"list-entry-data\": [\"entry-type-1:content\",\"entry-type-2:content\"] }' -output 'output-swagger.yml' list-manager entry-type-1`
  - Extended README.md with instruction to the new mechanism   
  - Issue45:
    - Test solution